### PR TITLE
Need to change the way you add the upload id.  This value can potenti…

### DIFF
--- a/multipart_upload.sh
+++ b/multipart_upload.sh
@@ -113,7 +113,7 @@ function upload_part {
   upload_args+=("bytes $range/*")
   upload_args+=('--vault-name')
   upload_args+=("$vault")
-  upload_args+=('--upload-id='"$upload_id")
+  upload_args+=("--upload-id=$upload_id")
 
   aws "${upload_args[@]}"
 
@@ -176,7 +176,7 @@ complete_args+=('--checksum' "$treehash")
 complete_args+=('--archive-size' "$file_size")
 complete_args+=('--vault-name')
 complete_args+=("$vault")
-complete_args+=('--upload-id' "$upload_id")
+complete_args+=("--upload-id=$upload_id")
 
 readonly result=$(aws "${complete_args[@]}")
 

--- a/multipart_upload.sh
+++ b/multipart_upload.sh
@@ -113,7 +113,7 @@ function upload_part {
   upload_args+=("bytes $range/*")
   upload_args+=('--vault-name')
   upload_args+=("$vault")
-  upload_args+=('--upload-id' "$upload_id")
+  upload_args+=('--upload-id='"$upload_id")
 
   aws "${upload_args[@]}"
 


### PR DESCRIPTION
…upload ID can potentially start with a hyphen which leads to issues thinking it is a new parameter which fails.  Adding the equals signs between --upload-id=<value> resolves the issue.