### PR TITLE
Level 12 instead 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can verify that your connection works by describing the vault you have creat
     -d --description  optinal description of the file
     -s --split-size   level that determines the size of the parts used for
                       uploading the file. The level can be a number between
-                      0 and 22 and results in part size of (2^level) MBytes.
+                      0 and 12 and results in part size of (2^level) MBytes.
                       If not specified the default is 0, i.e. the file is
                       uploaded in 1MByte parts.
     -h --help         print help message

--- a/glacierupload
+++ b/glacierupload
@@ -32,9 +32,9 @@ function print_usage {
   echo "    --description  optional description of the file"
   echo "    --split-size   level that determines the size of the parts used for"
   echo "                   uploading the file. The level can be a number between"
-  echo "                   0 and 22 and results in part size of (2^level) MBytes."
+  echo "                   0 and 12 and results in part size of (2^level) MBytes."
   echo "                   If not specified the default is 0, i.e. the file is"
-  echo "                   uploaded in 1MByte parts."
+  echo "                   uploaded in 1MByte parts. Maximum is 4GiB"
   echo "    --help         print this message"
 }
 
@@ -119,7 +119,7 @@ function byte_range {
 function multipart_upload {
   local -r archive="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 
-  # Only powers of 2 are allowed, max is 2**22
+  # Only powers of 2 are allowed, max is 2**12
   local -r part_size=$(( 2**split_size * MB ))
   local -r file_size=$(wc -c < "$archive")
 


### PR DESCRIPTION
 I noticed that max part size parameter can be 12 not 22. Otherwise
"An error occurred (InvalidParameterValueException) when calling the InitiateMultipartUpload operation: Invalid part size: 17179869184. Part size must not be null, must be a power of two and be between 1048576 and 4294967296 bytes."
I think the problem is here:
Line 16: MB=1048576
...
Line 123: local -r part_size=$(( 2**split_size * MB ))

so 1048576*2^split_size=4 398 046 511 104 (for 22) which is way too much (4 294 967 296)